### PR TITLE
Add theme info file to bstweaks

### DIFF
--- a/bstweaks.info.yml
+++ b/bstweaks.info.yml
@@ -1,0 +1,23 @@
+core: 8.x
+type: theme
+base theme: bootstrap
+
+name: 'RWAHS Bootstrap Sub-Theme (CDN)'
+description: 'Uses the jsDelivr CDN for all CSS and JavaScript. No source files or compiling is necessary and is recommended for simple sites or beginners.'
+package: 'Bootstrap'
+
+regions:
+  navigation: 'Navigation'
+  navigation_collapsible: 'Navigation (Collapsible)'
+  header: 'Top Bar'
+  highlighted: 'Highlighted'
+  help: 'Help'
+  content: 'Content'
+  sidebar_first: 'Primary'
+  sidebar_second: 'Secondary'
+  footer: 'Footer'
+  page_top: 'Page top'
+  page_bottom: 'Page bottom'
+
+libraries:
+  - 'bstweaks/global-styling'


### PR DESCRIPTION
- Makes it possible to enable the theme

I tried to enable this theme on a local Drupal site and it didn't have the theme info file. It wasn't in the original theme PR, and the file exists in the starterkit, and the instructions say to drop it in.
